### PR TITLE
Hotfix - fixed "Missing required key (base_theme)... error message"

### DIFF
--- a/lark.info.yml
+++ b/lark.info.yml
@@ -3,7 +3,7 @@ type: theme
 description: 'An Administrative theme from Mobomo.'
 core: 8.x
 core_version_requirement: ^8 || ^9
-base_theme: none
+base theme: false
 libraries:
   - lark/global-styling
   - drupal/jquery


### PR DESCRIPTION
Received the following error when I tried to install Lark in my Drupal environment: 

![Screen Shot 2020-07-10 at 4 44 02 PM](https://user-images.githubusercontent.com/16579792/87201430-9361d280-c2cc-11ea-9f76-d008e7fe9300.png)

