### PR TITLE
fix-dependency-warning

### DIFF
--- a/lark.info.yml
+++ b/lark.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 core_version_requirement: ^8 || ^9
 base theme: false
 dependencies:
-  search
+  - search
 libraries:
   - lark/global-styling
   - drupal/jquery


### PR DESCRIPTION
When running a `drush pm:uninstall` on a site with Lark enabled the following warning is generated:
```
 [warning] in_array() expects parameter 2 to be array, string given ModuleRequiredByThemesUninstallValidator.php:76
 ```

 This caused by the dependencies key in `lark.info.yml` not being in array syntax.