### PR TITLE
adjust z-index of ui-dialog so not partially hidden behind banner

### DIFF
--- a/scss/components/_drupal-tabs.scss
+++ b/scss/components/_drupal-tabs.scss
@@ -5,7 +5,8 @@
   overflow-x: auto;
 }
 
-.drupal-tabs__items {
+.drupal-tabs__items,
+.drupal-tabs--secondary {
   display: flex;
   justify-content: left;
   margin: 0;
@@ -19,12 +20,14 @@
 
 }
 
-.drupal-tabs__item {
+.drupal-tabs__item,
+.drupal-tabs--secondary > li {
   background-color: transparent;
   min-width: 150px;
 }
 
-.drupal-tabs__link {
+.drupal-tabs__link,
+.drupal-tabs--secondary > li > a {
   @include font(sans, bold);
   display: inline-block;
   padding: 16px;
@@ -43,7 +46,8 @@
 
 }
 
-.drupal-tabs__link--active {
+.drupal-tabs__link--active,
+.drupal-tabs--secondary > li > .is-active {
   box-shadow: inset 0 -4px 0 0 $primary;
   font-weight: 700;
 

--- a/scss/components/_tabledrag.scss
+++ b/scss/components/_tabledrag.scss
@@ -1,0 +1,11 @@
+// Override system styling from:
+// core/modules/system/css/components/tabledrag.module.css
+.draggable {
+  .tabledrag-handle {
+    .handle {
+      margin: -0.2em 0.5em 0;
+      background-position: center center;
+      height: 100%;
+    }
+  }
+}

--- a/scss/components/_toolbar.scss
+++ b/scss/components/_toolbar.scss
@@ -13,3 +13,10 @@
     }
   }
 }
+
+// Give dialog/modal higher z-index so doesn't hide below site banner
+.toolbar-tray-open {
+  .ui-dialog {
+    z-index: 502;
+  }
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -28,5 +28,6 @@
 @import './components/sidebar-menu';
 @import './components/site-banner';
 @import './components/site-branding';
+@import './components/tabledrag';
 @import './components/toolbar';
 @import './components/vertical-tabs';


### PR DESCRIPTION
Fix for three issues.  

- Adjust z-index of dialog
- Apply styles from drupal-tabs to the secondary menu that sits below it.
- Also including adjusting issue of tabledrag icon being hidden. (did not create issue for that one, sorry)

Fixes #22 
Fixes #23 
