### PR TITLE
Make the block layout page more user friendly

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -47,3 +47,10 @@
 
 }
 
+.button--small {
+  margin: 0.75rem 0.5rem 0.75rem 0;
+  padding: calc(0.5rem - 1px) calc(1rem - 1px);
+  min-height: auto;
+  font-size: 1rem;
+  font-weight: normal;
+}

--- a/scss/components/_tabledrag.scss
+++ b/scss/components/_tabledrag.scss
@@ -2,6 +2,8 @@
 // core/modules/system/css/components/tabledrag.module.css
 .draggable {
   .tabledrag-handle {
+    margin-left: 0 !important;
+
     .handle {
       margin: -0.2em 0.5em 0;
       background-position: center center;

--- a/scss/root/_forms.scss
+++ b/scss/root/_forms.scss
@@ -142,6 +142,10 @@ select {
   appearance: none;
 }
 
+.form-actions {
+  padding-top: 2rem;
+}
+
 .node-form {
   > .form-wrapper {
     padding: 10px 0;

--- a/scss/root/_tables.scss
+++ b/scss/root/_tables.scss
@@ -1,3 +1,5 @@
+@import '../core/variables';
+
 table,
 .table {
   width: 100%;
@@ -67,6 +69,7 @@ th,
 
 tr,
 .tr {
+  border-bottom: 0.0625rem solid $light-gray;
 
   &:hover {
     background-color: rgba($primary, 0.15);


### PR DESCRIPTION
<img width="1349" alt="Screen Shot 2020-09-28 at 2 22 44 PM" src="https://user-images.githubusercontent.com/10660823/94471002-6e2b8480-0196-11eb-92b4-b8749b9dc239.png">
